### PR TITLE
Fix next episode artwork fallback v33

### DIFF
--- a/.github/workflows/branch-next-episode-artwork-v33.yml
+++ b/.github/workflows/branch-next-episode-artwork-v33.yml
@@ -1,0 +1,91 @@
+name: Branch Next Episode Artwork v33
+
+on:
+  push:
+    branches:
+      - fix-next-episode-artwork-v33
+
+permissions:
+  contents: write
+
+concurrency:
+  group: branch-next-episode-artwork-v33
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v6
+        with:
+          ref: fix-next-episode-artwork-v33
+          fetch-depth: 0
+
+      - id: pending
+        name: Check whether repair is pending
+        shell: bash
+        run: |
+          if [ -f scripts/fix-next-episode-artwork-v33.mjs ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.pending.outputs.value == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Apply scoped repair
+        if: steps.pending.outputs.value == 'true'
+        run: node scripts/fix-next-episode-artwork-v33.mjs
+
+      - name: Install dependencies
+        if: steps.pending.outputs.value == 'true'
+        run: npm ci --include=dev
+
+      - name: TypeScript check
+        if: steps.pending.outputs.value == 'true'
+        run: npm run typecheck
+
+      - name: Full regression suite
+        if: steps.pending.outputs.value == 'true'
+        run: node --test scripts/tests/*.test.mjs
+
+      - name: Static player audit
+        if: steps.pending.outputs.value == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -F 'const movieEndOverlayStart = Math.max(0, duration - 5);' App.tsx
+          grep -F 'styles.nextEpisodeOverlay,' App.tsx
+          grep -F 'frameRect,' App.tsx
+          grep -F 'fallback={item.backdropFallback || item.backdrop || item.posterFallback || item.poster}' App.tsx
+          grep -F 'localFallback={localArtworkForItem(item)}' App.tsx
+          grep -F 'installStartupContentGate' index.ts
+          test ! -e src/collectionFlatListGuard.tsx
+
+      - name: Commit validated repair
+        if: steps.pending.outputs.value == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f scripts/fix-next-episode-artwork-v33.mjs .github/workflows/branch-next-episode-artwork-v33.yml
+          if ! grep -Fq '# milestone Next episode artwork fallback v33' PROJECT-STATE.md; then
+            cat >> PROJECT-STATE.md <<'EOF'
+
+# milestone Next episode artwork fallback v33 — 2026-08-19
+- Final-five-second/end-of-playback timing, compact frame-relative overlay and landscape safe-area behavior from v31 were audited and preserved.
+- The next-episode card still prefers unique episode artwork, but if that episode does not yet have a generated/remote still it now falls back to the series backdrop/poster (and bundled local fallback) instead of rendering an empty dark image area.
+- Episode list cards still reject recycled series art as exact episode artwork; this fallback is scoped only to the single next-episode end card.
+- Validation: npm ci, TypeScript, full Mobile regression suite and static player audit green. Physical-device appearance still requires the next device build/check.
+EOF
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add App.tsx PROJECT-STATE.md scripts/tests/next-episode-artwork-fallback-v33.test.mjs scripts/fix-next-episode-artwork-v33.mjs .github/workflows/branch-next-episode-artwork-v33.yml
+          git commit -m "fix: ensure next episode card always has artwork"
+          git push origin HEAD:fix-next-episode-artwork-v33

--- a/scripts/fix-next-episode-artwork-v33.mjs
+++ b/scripts/fix-next-episode-artwork-v33.mjs
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+
+const path = 'App.tsx';
+let src = fs.readFileSync(path, 'utf8');
+
+const oldText = `              <CatalogArtwork
+                primary={exactEpisodeArtworkFor(nextEpisodeGroup, item)}
+                style={styles.nextEpisodeArtwork}
+                contentFit="cover"
+                imageKind="backdrop"
+              />`;
+
+const newText = `              <CatalogArtwork
+                primary={exactEpisodeArtworkFor(nextEpisodeGroup, item)}
+                fallback={item.backdropFallback || item.backdrop || item.posterFallback || item.poster}
+                localFallback={localArtworkForItem(item)}
+                style={styles.nextEpisodeArtwork}
+                contentFit="cover"
+                imageKind="backdrop"
+              />`;
+
+const count = src.split(oldText).length - 1;
+if (count !== 1) throw new Error(`next episode artwork card: expected exactly one match, got ${count}`);
+src = src.replace(oldText, newText);
+fs.writeFileSync(path, src);
+console.log('next episode artwork fallback applied');

--- a/scripts/tests/next-episode-artwork-fallback-v33.test.mjs
+++ b/scripts/tests/next-episode-artwork-fallback-v33.test.mjs
@@ -4,6 +4,8 @@ import test from 'node:test';
 
 const app = fs.readFileSync('App.tsx', 'utf8');
 
+// Regression guard for the end-card visual fallback only; episode-list artwork
+// continues to require exact/unique episode imagery.
 test('next episode overlay keeps unique episode art but never renders blank when it is missing', () => {
   assert.match(app, /primary=\{exactEpisodeArtworkFor\(nextEpisodeGroup, item\)\}/);
   assert.match(app, /fallback=\{item\.backdropFallback \|\| item\.backdrop \|\| item\.posterFallback \|\| item\.poster\}/);

--- a/scripts/tests/next-episode-artwork-fallback-v33.test.mjs
+++ b/scripts/tests/next-episode-artwork-fallback-v33.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const app = fs.readFileSync('App.tsx', 'utf8');
+
+test('next episode overlay keeps unique episode art but never renders blank when it is missing', () => {
+  assert.match(app, /primary=\{exactEpisodeArtworkFor\(nextEpisodeGroup, item\)\}/);
+  assert.match(app, /fallback=\{item\.backdropFallback \|\| item\.backdrop \|\| item\.posterFallback \|\| item\.poster\}/);
+  assert.match(app, /localFallback=\{localArtworkForItem\(item\)\}/);
+});


### PR DESCRIPTION
Closed without merge after re-audit: the user evidence predates the already-merged v31 player repair. Current main already has final-5-second timing, frame/safe-area positioning, compact cards and unique episode artwork support with regression coverage. The additional fallback would be speculative without a new device regression.