### PR TITLE
fix: merge live catalog before Home reveal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7785,7 +7785,6 @@ function AppContent() {
       if (cachedLive?.items.length) {
         startupFallbackContentRef.current = cachedLive;
         applyContent(cachedLive);
-        dismissStartup();
       }
 
       if (online) {
@@ -7850,12 +7849,11 @@ function AppContent() {
     };
 
     if (hasBundledCatalog) {
-      // The APK carries a real compact Home snapshot. Reveal it on the first
-      // React frame; network/cache refreshes must never own the startup cover.
-      dismissStartup();
-      // Keep the first Home interaction free of multi-megabyte catalog parsing.
-      // The real bootstrap refresh must start immediately on first install;
-      // InteractionManager remains reserved for later periodic/app-state refreshes.
+      // Keep the complete APK snapshot mounted behind Startup, then reveal Home
+      // only after the small cumulative live delta has been merged. Otherwise a
+      // build-time title count is visibly replaced by newer syncs a few seconds
+      // after Home appears. Offline launches still reveal the APK snapshot from
+      // reloadContent as soon as network state is known.
       void reloadContent(false);
     } else {
       void reloadContent();

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "آپاراتچی",
     "slug": "aparatchi-mobile",
     "scheme": "aparatchi",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
@@ -16,7 +16,7 @@
       "package": "com.aparatchi.mobile",
       "icon": "./assets/icon.png",
       "predictiveBackGestureEnabled": false,
-      "versionCode": 33,
+      "versionCode": 34,
       "permissions": [
         "android.permission.ACCESS_NETWORK_STATE"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aparatchi-mobile",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aparatchi-mobile",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "expo": "~57.0.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aparatchi-mobile",
   "description": "Aparatchi mobile app for Android and iOS.",
   "private": true,
-  "version": "0.16.3",
+  "version": "0.16.4",
   "main": "index.ts",
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",

--- a/scripts/tests/device-root-v37.test.mjs
+++ b/scripts/tests/device-root-v37.test.mjs
@@ -5,12 +5,12 @@ import test from 'node:test';
 const app = fs.readFileSync('App.tsx','utf8');
 const service = fs.readFileSync('src/contentService.ts','utf8');
 
-test('cold start reveals bundled/live cache before remote work', () => {
+test('cold start keeps bundled/live cache behind Startup until current live truth', () => {
   const effectStart = app.indexOf('if (hasBundledCatalog) {');
   const effectEnd = app.indexOf('} else {', effectStart);
   const effect = app.slice(effectStart, effectEnd);
-  assert.ok(effect.indexOf('dismissStartup();') >= 0);
-  assert.ok(effect.indexOf('dismissStartup();') < effect.indexOf('void reloadContent(false);'));
+  assert.ok(!effect.includes('dismissStartup();'));
+  assert.ok(effect.includes('void reloadContent(false);'));
 
   const start = app.indexOf('if (online) {', app.indexOf('const reloadContent = async'));
   const end = app.indexOf('const firstApplied = applyContent(firstContent);', start);
@@ -18,6 +18,9 @@ test('cold start reveals bundled/live cache before remote work', () => {
   assert.ok(start >= 0 && end > start);
   assert.ok(block.indexOf('await loadLiveContent(contentRef.current)') >= 0);
   assert.ok(app.includes('const cachedLive = initialLoad ? await loadCachedLiveContent(contentRef.current) : null;'));
+  const cachedStart = app.indexOf('if (cachedLive?.items.length) {', app.indexOf('const reloadContent = async'));
+  const onlineStart = app.indexOf('if (online) {', cachedStart);
+  assert.ok(!app.slice(cachedStart, onlineStart).includes('dismissStartup();'));
   assert.ok(!block.includes('firstContent = await loadContent(true)'));
   assert.ok(!block.includes('loadContent('));
   assert.ok(!block.includes('loadContent(false, true)'));

--- a/scripts/tests/first-install-freshness-v33.test.mjs
+++ b/scripts/tests/first-install-freshness-v33.test.mjs
@@ -21,15 +21,15 @@ test('bootstrap mirrors race instead of stacking timeout costs', async () => {
   assert.ok(bootstrap.indexOf('const manifestPromise =') < bootstrap.indexOf('candidates.forEach((candidate, index) => {'));
 });
 
-test('first install has a real bundled catalog instead of a network-owned splash', async () => {
+test('first install keeps a real bundled fallback without flashing stale Home', async () => {
   const app = await fs.readFile('App.tsx', 'utf8');
   const bundled = JSON.parse(await fs.readFile('src/catalogBootstrap.json', 'utf8'));
   const start = app.indexOf('if (hasBundledCatalog) {');
   const end = app.indexOf('} else {', start);
   const block = app.slice(start, end);
   assert.ok(bundled.items.length >= 100);
-  assert.ok(block.indexOf('dismissStartup();') >= 0);
-  assert.ok(block.indexOf('dismissStartup();') < block.indexOf('void reloadContent(false);'));
+  assert.ok(!block.includes('dismissStartup();'));
+  assert.ok(block.includes('void reloadContent(false);'));
 });
 
 test('manifest Raw and CDN requests start together with a bounded source-truth window', async () => {

--- a/scripts/tests/instant-startup-cache-v41.test.mjs
+++ b/scripts/tests/instant-startup-cache-v41.test.mjs
@@ -14,14 +14,18 @@ test('APK carries the complete current startup navigation snapshot', () => {
   assert.ok(fs.statSync('src/catalogBootstrap.json').size < 10_000_000);
 });
 
-test('startup is stale-while-revalidate and never network-gated', () => {
+test('startup merges the uncapped live delta before revealing Home', () => {
   assert.ok(service.includes("import bundledBootstrapJson from './catalogBootstrap.json';"));
   assert.ok(service.includes('export async function loadCachedLiveContent(base: LoadedContent)'));
   assert.ok(app.includes('const cachedLive = initialLoad ? await loadCachedLiveContent(contentRef.current) : null;'));
   const start = app.indexOf('if (hasBundledCatalog) {');
   const end = app.indexOf('} else {', start);
   const block = app.slice(start, end);
-  assert.ok(block.indexOf('dismissStartup();') < block.indexOf('void reloadContent(false);'));
+  assert.ok(!block.includes('dismissStartup();'));
+  assert.ok(block.includes('void reloadContent(false);'));
+  const cachedStart = app.indexOf('if (cachedLive?.items.length) {', app.indexOf('const reloadContent = async'));
+  const onlineStart = app.indexOf('if (online) {', cachedStart);
+  assert.ok(!app.slice(cachedStart, onlineStart).includes('dismissStartup();'));
 });
 
 test('large index cannot steal the startup path', () => {

--- a/scripts/tests/startup-live-truth-v46.test.mjs
+++ b/scripts/tests/startup-live-truth-v46.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const app = fs.readFileSync('App.tsx', 'utf8');
+
+test('online cold start never reveals a build-time count before live growth is merged', () => {
+  const reloadStart = app.indexOf('const reloadContent = async');
+  const effectStart = app.indexOf('useEffect(() => {', reloadStart);
+  const reload = app.slice(reloadStart, effectStart);
+  const cachedStart = reload.indexOf('if (cachedLive?.items.length) {');
+  const onlineStart = reload.indexOf('if (online) {', cachedStart);
+  const liveStart = reload.indexOf('liveContent = await loadLiveContent(contentRef.current)', onlineStart);
+  const liveApplied = reload.indexOf('if (applyContent(liveContent)) {', liveStart);
+  const liveDismissed = reload.indexOf('dismissStartup();', liveApplied);
+
+  assert.ok(cachedStart >= 0 && onlineStart > cachedStart);
+  assert.ok(!reload.slice(cachedStart, onlineStart).includes('dismissStartup();'));
+  assert.ok(liveStart > onlineStart && liveApplied > liveStart && liveDismissed > liveApplied);
+});
+
+test('offline cold start still falls back to the complete bundled catalog', () => {
+  const reloadStart = app.indexOf('const reloadContent = async');
+  const effectStart = app.indexOf('useEffect(() => {', reloadStart);
+  const reload = app.slice(reloadStart, effectStart);
+  assert.ok(reload.includes('firstContent = cachedLive || contentRef.current;'));
+  assert.ok(reload.includes('const firstApplied = applyContent(firstContent);'));
+  assert.ok(reload.includes('if (firstApplied) {\n        dismissStartup();'));
+});


### PR DESCRIPTION
Fixes the remaining visible catalog-refresh delay after newer Content syncs.

- keeps the complete bundled snapshot mounted behind Startup
- on online cold start, reveals Home only after the cumulative uncapped live delta is merged
- keeps immediate complete bundled fallback for offline launches
- removes the visible build-time-count → current-count jump
- bumps Android to 0.16.4 (versionCode 34)

Validation: TypeScript passed, 63/63 Mobile regressions passed, and Expo Android production export passed.