### PR TITLE
Fix release transformer after Persian collection fallback

### DIFF
--- a/scripts/mobile-source-patches.cjs
+++ b/scripts/mobile-source-patches.cjs
@@ -4,6 +4,7 @@ function replaceOnce(source, before, after, label) {
   if (source.includes(after)) return source;
   if (label === 'collection scroll callback' && source.includes('const rememberCollectionFolderOffset = useCallback')) return source;
   if (label === 'collection scroll restore' && source.includes('onScroll={rememberCollectionFolderOffset}')) return source;
+  if (label === 'collection folder identity' && source.includes("firstFa && hasPersianScript(firstFa)")) return source;
   const count = source.split(before).length - 1;
   if (count !== 1) {
     throw new Error(`${label}: expected exactly one source anchor, found ${count}`);


### PR DESCRIPTION
Makes the Metro source patch recognize the already-correct Persian collection fallback. Full mobile tests 66/66; direct transformer smoke test passes.